### PR TITLE
Add MongoDB tasks endpoint and loading spinner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # Codex Todo
 
 This is a simple ReactJS to-do list application built with [Vite](https://vitejs.dev/).
-Tasks are stored using React's `useState` hook and there is no external state
-management library.
+Tasks are fetched from a small Express server backed by MongoDB.
 
 ## Getting Started
 
-Install dependencies and start the development server:
+Install dependencies and start both the React app and the API server:
 
 ```bash
 npm install
+# start the API server
+npm run server &
+# then start the front-end
 npm run dev
 ```
 

--- a/package.json
+++ b/package.json
@@ -7,11 +7,15 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server.js"
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "mongoose": "^8.3.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,34 @@
+import express from 'express'
+import mongoose from 'mongoose'
+import cors from 'cors'
+
+const app = express()
+const PORT = process.env.PORT || 3000
+
+app.use(cors())
+app.use(express.json())
+
+mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/todos', {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+})
+
+const taskSchema = new mongoose.Schema({
+  text: String,
+  completed: Boolean,
+})
+
+const Task = mongoose.model('Task', taskSchema)
+
+app.get('/api/tasks', async (req, res) => {
+  try {
+    const tasks = await Task.find()
+    res.json(tasks)
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch tasks' })
+  }
+})
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`)
+})

--- a/src/App.css
+++ b/src/App.css
@@ -30,3 +30,19 @@
 .completed {
   text-decoration: line-through;
 }
+
+.spinner {
+  width: 24px;
+  height: 24px;
+  border: 4px solid #ccc;
+  border-top-color: #646cff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 1rem auto;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,15 +3,18 @@ import TodoList from './TodoList.jsx'
 import './App.css'
 
 function App() {
-  const [tasks, setTasks] = useState(() => {
-    const saved = localStorage.getItem('tasks')
-    return saved ? JSON.parse(saved) : []
-  })
+  const [tasks, setTasks] = useState([])
+  const [loading, setLoading] = useState(false)
   const [text, setText] = useState('')
 
   useEffect(() => {
-    localStorage.setItem('tasks', JSON.stringify(tasks))
-  }, [tasks])
+    setLoading(true)
+    fetch('http://localhost:3000/api/tasks')
+      .then((res) => res.json())
+      .then((data) => setTasks(data))
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [])
 
   const addTask = (e) => {
     e.preventDefault()
@@ -46,7 +49,11 @@ function App() {
         />
         <button type="submit">Add</button>
       </form>
-      <TodoList tasks={tasks} onToggle={toggleTask} onDelete={deleteTask} />
+      {loading ? (
+        <div className="spinner" aria-label="loading" />
+      ) : (
+        <TodoList tasks={tasks} onToggle={toggleTask} onDelete={deleteTask} />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- create simple Express server backed by MongoDB
- fetch tasks from `/api/tasks` and show a spinner while loading
- add spinner styles
- document server setup in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*